### PR TITLE
Add new sandbox_load_interval config parameter

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,8 +50,9 @@ The Hindsight infrastructure can be run as a service with no initial business lo
 be dynamically loaded and unloaded as necessary.
 
 ```lua
-sandbox_load_path = "hs_load"
-sandbox_run_path  = "hs_run"
+sandbox_load_path     = "hs_load"
+sandbox_load_interval = 60
+sandbox_run_path      = "hs_run"
 ```
 
 ##### Starting a New Plugin

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,10 @@
   * input (directory) - input plugin queue
   * analysis (directory) - analysis plugin queue
   * output (directory) - output plugin queue
-* **sandbox_load_interval** - time interval at which the `sandbox_load_path` directory should be scanned for new dynamic plugins to load (seconds, default 60)
+* **sandbox_load_interval** - time interval at which the `sandbox_load_path` directory should be scanned for new
+dynamic plugins to load (seconds, default 60).
+Please note that dynamic loading can introduce latency into the pipeline (since everything needs to be locked down
+in that thread of execution), so you don't really want a value lower than 60 seconds on production.
 * **sandbox_run_path** - base path containing the running cfgs, Lua, and state preservation files.
   The following directory structure must exist under the base path:
   * input (directory) - input plugins

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,7 @@
   * input (directory) - input plugin queue
   * analysis (directory) - analysis plugin queue
   * output (directory) - output plugin queue
+* **sandbox_load_interval** - time interval at which the `sandbox_load_path` directory should be scanned for new dynamic plugins to load (seconds, default 60)
 * **sandbox_run_path** - base path containing the running cfgs, Lua, and state preservation files.
   The following directory structure must exist under the base path:
   * input (directory) - input plugins
@@ -30,6 +31,7 @@
 output_path             = "hs_output"
 output_size             = 1024 * 1024 * 1024
 sandbox_load_path       = "hs_load"
+sandbox_load_interval   = 60
 sandbox_run_path        = "hs_run"
 analysis_threads        = 1
 analysis_lua_path       = "/usr/lib/luasandbox/modules/?.lua"

--- a/src/hindsight.c
+++ b/src/hindsight.c
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
   hs_init_checkpoint_writer(&cpw, &ips, &aps, &ops, cfg.output_path);
 
   struct timespec ts;
-  int cnt = 0;
+  unsigned cnt = 0;
   while (true) {
     if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
       hs_log(g_module, 3, "clock_gettime failed");
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
       break; // shutting down
     }
     hs_write_checkpoints(&cpw, &cfg.cp_reader);
-    if (cfg.load_path[0] != 0 && ++cnt == 59) { // scan just before emitting the stats
+    if (cfg.load_path[0] != 0 && ++cnt == cfg.load_interval) { // scan just before emitting the stats
       hs_log(g_module, 7, "scan load directories");
       hs_load_input_plugins(&ips, &cfg, true);
       hs_load_analysis_plugins(&aps, &cfg, true);

--- a/src/hindsight.c
+++ b/src/hindsight.c
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
       break; // shutting down
     }
     hs_write_checkpoints(&cpw, &cfg.cp_reader);
-    if (cfg.load_path[0] != 0 && ++cnt == cfg.load_interval) { // scan just before emitting the stats
+    if (cfg.load_path[0] != 0 && ++cnt == cfg.load_interval) {
       hs_log(g_module, 7, "scan load directories");
       hs_load_input_plugins(&ips, &cfg, true);
       hs_load_analysis_plugins(&aps, &cfg, true);

--- a/src/hs_config.c
+++ b/src/hs_config.c
@@ -31,6 +31,7 @@ static const char g_module[] = "config_parser";
 static const char* cfg_output_path = "output_path";
 static const char* cfg_output_size = "output_size";
 static const char* cfg_load_path = "sandbox_load_path";
+static const char* cfg_load_interval = "sandbox_load_interval";
 static const char* cfg_run_path = "sandbox_run_path";
 static const char* cfg_threads = "analysis_threads";
 static const char* cfg_analysis_lua_path = "analysis_lua_path";
@@ -75,6 +76,7 @@ static void init_config(hs_config* cfg)
 {
   cfg->run_path = NULL;
   cfg->load_path = NULL;
+  cfg->load_interval = 60;
   cfg->output_path = NULL;
   cfg->io_lua_path = NULL;
   cfg->io_lua_cpath = NULL;
@@ -414,6 +416,14 @@ int hs_load_config(const char* fn, hs_config* cfg)
 
   ret = get_string_item(L, LUA_GLOBALSINDEX, cfg_load_path, &cfg->load_path,
                         "");
+  if (ret) goto cleanup;
+
+  ret = get_numeric_item(L, LUA_GLOBALSINDEX, cfg_load_interval,
+                         &cfg->load_interval);
+  if (cfg->load_interval < 1) {
+    lua_pushfstring(L, "%s must be >= 1", cfg_load_interval);
+    ret = 1;
+  }
   if (ret) goto cleanup;
 
   ret = get_string_item(L, LUA_GLOBALSINDEX, cfg_run_path, &cfg->run_path,

--- a/src/hs_config.h
+++ b/src/hs_config.h
@@ -53,6 +53,7 @@ typedef struct hs_config
 {
   char* run_path;
   char* load_path;
+  unsigned load_interval;
   char* output_path;
   char* io_lua_path;
   char* io_lua_cpath;

--- a/src/hs_config.h
+++ b/src/hs_config.h
@@ -53,7 +53,6 @@ typedef struct hs_config
 {
   char* run_path;
   char* load_path;
-  unsigned load_interval;
   char* output_path;
   char* io_lua_path;
   char* io_lua_cpath;
@@ -63,6 +62,7 @@ typedef struct hs_config
   unsigned max_message_size;
   unsigned output_size;
   unsigned analysis_threads;
+  unsigned load_interval;
   int pid;
   hs_checkpoint_reader cp_reader;
   hs_sandbox_config ipd; // input plugin defaults


### PR DESCRIPTION
This allows to customize the time interval used by Hinsight to scan the `sandbox_load_path` for new dynamic plugins to load.

I need this new param for testing purpose: I've developed a small testing utility in Python which uses the great Hindsight feature of dynamic loading of sandboxes to easily test my own Lua sandboxes.
I don't want it to wait during 1min between every tests for Hindsight to scan the `sandbox_load_path` directory, so I set the new `sandbox_load_interval` config parameter to 1 second.