### PR TITLE
Support plugin configuration to remove checkpoint if manually stopped

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,8 @@
   are both on the same file (count, default 0 (no backpressure))
   e.g. backpressure = 10 [writer = 100.log, slowest reader = 89.log, delta = 11]
 * **hostname** - hostname used in logging/messages (default gethostname())
+* **remove_checkpoint_on_stop** - removes the checkpoint entry when the plugin
+  is stopped, terminated, or has been manually removed (default false)
 
 ```lua
 output_path             = "output"

--- a/src/hindsight.c
+++ b/src/hindsight.c
@@ -71,6 +71,11 @@ int main(int argc, char *argv[])
     return EXIT_FAILURE;
   }
 
+  if (cfg.rm_checkpoint) {
+    hs_cleanup_checkpoints(&cfg.cp_reader, cfg.run_path,
+                           cfg.analysis_threads);
+  }
+
   hs_log(NULL, g_module, 6, "starting");
   signal(SIGINT, stop_signal);
 

--- a/src/hs_checkpoint_reader.h
+++ b/src/hs_checkpoint_reader.h
@@ -77,4 +77,11 @@ void hs_update_input_checkpoint(hs_checkpoint_reader *cpr,
 
 void hs_output_checkpoints(hs_checkpoint_reader *cpr, FILE *fh);
 
+void hs_remove_checkpoint(hs_checkpoint_reader *cpr,
+                                const char *key);
+
+void hs_cleanup_checkpoints(hs_checkpoint_reader *cpr,
+                                  const char *run_path,
+                                  int analysis_threads);
+
 #endif

--- a/src/hs_config.c
+++ b/src/hs_config.c
@@ -41,6 +41,7 @@ static const char *cfg_io_lua_cpath = "io_lua_cpath";
 static const char *cfg_max_message_size = "max_message_size";
 static const char *cfg_hostname = "hostname";
 static const char *cfg_backpressure = "backpressure";
+static const char *cfg_rm_checkpoint = "remove_checkpoint_on_stop";
 
 static const char *cfg_sb_ipd = "input_defaults";
 static const char *cfg_sb_apd = "analysis_defaults";
@@ -86,6 +87,7 @@ static void init_config(hs_config *cfg)
   cfg->analysis_threads = 1;
   cfg->max_message_size = 1024 * 64;
   cfg->backpressure = 0;
+  cfg->rm_checkpoint = false;
   cfg->pid = (int)getpid();
   init_sandbox_config(&cfg->ipd);
   init_sandbox_config(&cfg->apd);
@@ -486,6 +488,10 @@ int hs_load_config(const char *fn, hs_config *cfg)
     lua_pushfstring(L, "%s must be 1-64", cfg_threads);
     ret = 1;
   }
+  if (ret) goto cleanup;
+
+  ret = get_bool_item(L, LUA_GLOBALSINDEX, cfg_rm_checkpoint,
+                      &cfg->rm_checkpoint);
   if (ret) goto cleanup;
 
   ret = load_sandbox_defaults(L, cfg_sb_ipd, &cfg->ipd);

--- a/src/hs_config.h
+++ b/src/hs_config.h
@@ -56,6 +56,7 @@ typedef struct hs_config
   unsigned output_size;
   unsigned analysis_threads;
   unsigned backpressure;
+  bool rm_checkpoint;
   int pid;
   hs_checkpoint_reader cp_reader;
   hs_sandbox_config ipd; // input plugin defaults


### PR DESCRIPTION
See #24.

> I would clarify stopping as exiting NOT due to a Hindsight shutdown (on a shutdown the checkpoint should still be preserved)
> e.g., remove_checkpoint_on_stop = false/true (defaulting to false, the current behaviour)

So plugin checkpoint should be removed when `remove_checkpoint_on_stop = true` in the 2 following cases:
- the plugin is dynamically stopped (by following procedure from https://github.com/trink/hindsight/blob/master/docs/architecture.md#stopping-a-plugin)
- Hindsight is shutdown, the plugin is removed from the `sandbox_run_path` directory, and hindsight is started again