### PR TITLE
Fix 32bit arm compilation issue with pointer casting

### DIFF
--- a/src/hs_output_plugins.c
+++ b/src/hs_output_plugins.c
@@ -67,7 +67,7 @@ static int update_checkpoint_callback(void *parent, void *sequence_id)
   hs_output_plugin *p = parent;
 
   if (sequence_id && p->async_cp) {
-    int i = (unsigned long long)sequence_id % p->async_len;
+    int i = (uintptr_t)sequence_id % p->async_len;
     pthread_mutex_lock(&p->cp_lock);
     if (p->async_cp[i].input.id >= p->cp.input.id
         && p->async_cp[i].input.offset > p->cp.input.offset) {

--- a/src/hs_output_plugins.h
+++ b/src/hs_output_plugins.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <time.h>
+#include <stdint.h>
 
 #include "hs_config.h"
 #include "hs_input.h"
@@ -31,7 +32,7 @@ struct hs_output_plugin {
   lsb_heka_sandbox    *hsb;
   lsb_message_matcher *mm;
   hs_output_plugins   *plugins;
-  unsigned long long  sequence_id;
+  uintptr_t  sequence_id;
   lsb_running_stats   mms;
   int                 ticker_interval;
   time_t              ticker_expires;


### PR DESCRIPTION
Use `uintptr_t` type instead of `unsigned long long` so that it compiles both on 32bit and 64bit architectures.

I'm not sure this is the right fix but it resolves issue #37.